### PR TITLE
Make env vars sensitive

### DIFF
--- a/circleci/provider.go
+++ b/circleci/provider.go
@@ -21,8 +21,8 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"circleci_project": 				resourceCircleciProject(),
-			"circleci_environment_variable": 	resourceCircleciEnvVar(),
+			"circleci_project":              resourceCircleciProject(),
+			"circleci_environment_variable": resourceCircleciEnvVar(),
 		},
 	}
 	p.ConfigureFunc = providerConfiguretest(p)

--- a/circleci/provider_test.go
+++ b/circleci/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"testing"
 )
+
 func TestProvider_HasChildResources(t *testing.T) {
 	expectedResources := []string{
 		"circleci_project",
@@ -21,8 +22,8 @@ func TestProvider_HasChildResources(t *testing.T) {
 
 func TestProvider_SchemaIsValid(t *testing.T) {
 	type testParams struct {
-		token          string
-		organization   string
+		token        string
+		organization string
 	}
 
 	tests := []testParams{

--- a/circleci/resource_circleci_environment_variable.go
+++ b/circleci/resource_circleci_environment_variable.go
@@ -24,8 +24,9 @@ func resourceCircleciEnvVar() *schema.Resource {
 				Required: true,
 			},
 			"value": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/circleci/resource_circleci_project.go
+++ b/circleci/resource_circleci_project.go
@@ -20,8 +20,9 @@ func resourceCircleciProject() *schema.Resource {
 				Required: true,
 			},
 			"env_vars": {
-				Type:     schema.TypeMap,
-				Optional: true,
+				Type:      schema.TypeMap,
+				Optional:  true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
Continues work started on #6. 
Makes `env_vars` sensitive on the `circleci_project` resource and `value` sensitive on the `circleci_environment_variable` resource